### PR TITLE
Add unit tests for core services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ lerna-debug.log*
 
 .env
 *.csv
+
+# SSH keys
+id_ed25519*

--- a/package.json
+++ b/package.json
@@ -85,6 +85,9 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1"
+    }
   }
 }

--- a/src/connection/azureSASToken.service.spec.ts
+++ b/src/connection/azureSASToken.service.spec.ts
@@ -1,0 +1,65 @@
+import { getAzureSASTokenService } from './azureSASToken.service';
+import { generateBlobSASQueryParameters, StorageSharedKeyCredential, BlobSASPermissions } from '@azure/storage-blob';
+
+jest.mock('@azure/storage-blob', () => ({
+  StorageSharedKeyCredential: jest.fn(),
+  BlobSASPermissions: { parse: jest.fn().mockReturnValue('rwcm') },
+  SASProtocol: { Https: 'https' },
+  generateBlobSASQueryParameters: jest.fn().mockReturnValue({ toString: () => 'sv=2024&sig=test' }),
+}));
+
+describe('getAzureSASTokenService', () => {
+  let service: getAzureSASTokenService;
+
+  beforeEach(() => {
+    service = new getAzureSASTokenService();
+    jest.clearAllMocks();
+
+    process.env.AZURE_STORAGE_ACCOUNT = 'teststorage';
+    process.env.AZURE_STORAGE_KEY = 'dGVzdGtleQ==';
+  });
+
+  describe('generateSasUrl', () => {
+    it('should generate container-level SAS URL when no blobName', async () => {
+      const url = await service.generateSasUrl();
+
+      expect(url).toBe('https://teststorage.blob.core.windows.net/tickets?sv=2024&sig=test');
+      expect(generateBlobSASQueryParameters).toHaveBeenCalled();
+      expect(StorageSharedKeyCredential).toHaveBeenCalledWith('teststorage', 'dGVzdGtleQ==');
+    });
+
+    it('should generate blob-level SAS URL when blobName is provided', async () => {
+      const url = await service.generateSasUrl('ticket-001.csv');
+
+      expect(url).toBe('https://teststorage.blob.core.windows.net/tickets/ticket-001.csv?sv=2024&sig=test');
+    });
+
+    it('should use correct permissions (rwcm)', async () => {
+      await service.generateSasUrl();
+
+      expect(BlobSASPermissions.parse).toHaveBeenCalledWith('rwcm');
+    });
+
+    it('should pass container name as tickets', async () => {
+      await service.generateSasUrl();
+
+      const callArgs = (generateBlobSASQueryParameters as jest.Mock).mock.calls[0][0];
+      expect(callArgs.containerName).toBe('tickets');
+    });
+
+    it('should set expiry based on expiresInHours param', async () => {
+      const before = new Date();
+      await service.generateSasUrl(undefined, 5);
+      const after = new Date();
+
+      const callArgs = (generateBlobSASQueryParameters as jest.Mock).mock.calls[0][0];
+      const expiry = callArgs.expiresOn as Date;
+
+      // Expiry should be approximately 5 hours from now
+      const expectedMin = new Date(before.getTime() + 5 * 60 * 60 * 1000 - 5000);
+      const expectedMax = new Date(after.getTime() + 5 * 60 * 60 * 1000 + 5000);
+      expect(expiry.getTime()).toBeGreaterThanOrEqual(expectedMin.getTime());
+      expect(expiry.getTime()).toBeLessThanOrEqual(expectedMax.getTime());
+    });
+  });
+});

--- a/src/connection/getToken.service.spec.ts
+++ b/src/connection/getToken.service.spec.ts
@@ -1,0 +1,100 @@
+import { getTokenService } from './getToken.service';
+import axios from 'axios';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('getTokenService', () => {
+  let service: getTokenService;
+
+  beforeEach(() => {
+    service = new getTokenService();
+    jest.clearAllMocks();
+
+    process.env.tenant = 'test-tenant';
+    process.env.token_type = 'Bearer';
+    process.env.grant_type = 'client_credentials';
+    process.env.client_id = 'test-client-id';
+    process.env.client_secret = 'test-client-secret';
+    process.env.scope = 'https://api.businesscentral.dynamics.com/.default';
+  });
+
+  describe('getToken', () => {
+    it('should return access token on success', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { access_token: 'test-token-123' },
+      });
+
+      const token = await service.getToken();
+
+      expect(token).toBe('test-token-123');
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'https://login.microsoftonline.com/test-tenant/oauth2/v2.0/token',
+        expect.any(URLSearchParams),
+      );
+    });
+
+    it('should send correct params', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { access_token: 'token' },
+      });
+
+      await service.getToken();
+
+      const params = mockedAxios.post.mock.calls[0][1] as URLSearchParams;
+      expect(params.get('tenant')).toBe('test-tenant');
+      expect(params.get('grant_type')).toBe('client_credentials');
+      expect(params.get('client_id')).toBe('test-client-id');
+      expect(params.get('client_secret')).toBe('test-client-secret');
+    });
+
+    it('should throw when response has no data', async () => {
+      mockedAxios.post.mockResolvedValueOnce({ data: null });
+
+      await expect(service.getToken()).rejects.toThrow('Failed to obtain access token');
+    });
+
+    it('should throw on network error', async () => {
+      mockedAxios.post.mockRejectedValueOnce(new Error('Network Error'));
+
+      await expect(service.getToken()).rejects.toThrow();
+    });
+  });
+
+  describe('getToken2', () => {
+    it('should return access token with custom credentials', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { access_token: 'custom-token-456' },
+      });
+
+      const token = await service.getToken2('custom-id', 'custom-secret', 'custom-tenant');
+
+      expect(token).toBe('custom-token-456');
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'https://login.microsoftonline.com/custom-tenant/oauth2/v2.0/token',
+        expect.any(URLSearchParams),
+      );
+    });
+
+    it('should use custom client_id and client_secret', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { access_token: 'token' },
+      });
+
+      await service.getToken2('my-id', 'my-secret', 'my-tenant');
+
+      const params = mockedAxios.post.mock.calls[0][1] as URLSearchParams;
+      expect(params.get('client_id')).toBe('my-id');
+      expect(params.get('client_secret')).toBe('my-secret');
+      expect(params.get('tenant')).toBe('my-tenant');
+    });
+
+    it('should throw when response has no data', async () => {
+      mockedAxios.post.mockResolvedValueOnce({ data: null });
+
+      await expect(service.getToken2('id', 'secret', 'tenant')).rejects.toThrow(
+        'Failed to obtain access token',
+      );
+    });
+  });
+});

--- a/src/connection/sqlConnection.service.spec.ts
+++ b/src/connection/sqlConnection.service.spec.ts
@@ -1,0 +1,67 @@
+import { runSqlService } from './sqlConnection.service';
+import * as sql from 'mssql';
+
+jest.mock('mssql');
+
+describe('runSqlService', () => {
+  let service: runSqlService;
+  let mockQuery: jest.Mock;
+  let mockRequest: jest.Mock;
+
+  beforeEach(() => {
+    service = new runSqlService();
+    jest.clearAllMocks();
+
+    mockQuery = jest.fn();
+    mockRequest = jest.fn().mockReturnValue({ query: mockQuery });
+
+    const mockPool = {
+      request: mockRequest,
+    };
+
+    (sql.ConnectionPool as any) = jest.fn().mockImplementation(() => ({
+      connect: jest.fn().mockResolvedValue(mockPool),
+    }));
+
+    process.env.user = 'testuser';
+    process.env.password = 'testpass';
+    process.env.server = 'testserver';
+  });
+
+  describe('runSql', () => {
+    it('should execute SQL query with USE prefix', async () => {
+      const expectedResult = { recordset: [{ id: 1, name: 'test' }] };
+      mockQuery.mockResolvedValueOnce(expectedResult);
+
+      // Force pool creation
+      await service.PoolCreation();
+      const result = await service.runSql('SELECT * FROM Users', 'testdb');
+
+      expect(mockQuery).toHaveBeenCalledWith('use testdb; SELECT * FROM Users');
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('should prepend USE statement to queries', async () => {
+      mockQuery.mockResolvedValueOnce({ recordset: [] });
+
+      await service.PoolCreation();
+      await service.runSql('SELECT 1', 'mydb');
+
+      expect(mockQuery).toHaveBeenCalledWith('use mydb; SELECT 1');
+    });
+
+    it('should return query result', async () => {
+      const records = [
+        { codi: '001', nom: 'Article 1' },
+        { codi: '002', nom: 'Article 2' },
+      ];
+      mockQuery.mockResolvedValueOnce({ recordset: records });
+
+      await service.PoolCreation();
+      const result = await service.runSql('SELECT * FROM Articles', 'hit');
+
+      expect(result.recordset).toHaveLength(2);
+      expect(result.recordset[0].codi).toBe('001');
+    });
+  });
+});

--- a/src/helpers/helpers.controller.spec.ts
+++ b/src/helpers/helpers.controller.spec.ts
@@ -1,0 +1,46 @@
+import { HelpersController } from './helpers.controller';
+import { readFileSync } from 'fs';
+
+jest.mock('fs', () => ({
+  readFileSync: jest.fn(),
+}));
+
+const mockReadFileSync = readFileSync as jest.MockedFunction<typeof readFileSync>;
+
+describe('HelpersController', () => {
+  let controller: HelpersController;
+
+  beforeEach(() => {
+    controller = new HelpersController();
+    jest.clearAllMocks();
+  });
+
+  describe('getLogs', () => {
+    it('should return parsed logs', () => {
+      const logs = [
+        { tipo: 'info', mensaje: 'test log 1' },
+        { tipo: 'error', mensaje: 'test log 2' },
+      ];
+      mockReadFileSync.mockReturnValueOnce(JSON.stringify(logs));
+
+      const result = controller.getLogs();
+
+      expect(result).toEqual(logs);
+      expect(result).toHaveLength(2);
+    });
+
+    it('should return empty array when log file is empty array', () => {
+      mockReadFileSync.mockReturnValueOnce('[]');
+
+      const result = controller.getLogs();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should throw on invalid JSON', () => {
+      mockReadFileSync.mockReturnValueOnce('invalid json');
+
+      expect(() => controller.getLogs()).toThrow();
+    });
+  });
+});

--- a/src/helpers/helpers.service.spec.ts
+++ b/src/helpers/helpers.service.spec.ts
@@ -1,0 +1,269 @@
+import { helpersService } from './helpers.service';
+import { writeFile, readFile, copyFile, access } from 'fs/promises';
+
+jest.mock('fs/promises');
+
+const mockWriteFile = writeFile as jest.MockedFunction<typeof writeFile>;
+const mockReadFile = readFile as jest.MockedFunction<typeof readFile>;
+const mockCopyFile = copyFile as jest.MockedFunction<typeof copyFile>;
+const mockAccess = access as jest.MockedFunction<typeof access>;
+
+describe('helpersService', () => {
+  let service: helpersService;
+
+  beforeEach(() => {
+    service = new helpersService();
+    jest.clearAllMocks();
+  });
+
+  describe('parseEsTimestamp', () => {
+    it('should parse a full Spanish timestamp (dd/mm/yyyy, hh:mm:ss)', () => {
+      const result = service.parseEsTimestamp('15/03/2025, 14:30:45');
+      expect(result).toBeInstanceOf(Date);
+      expect(result.getDate()).toBe(15);
+      expect(result.getMonth()).toBe(2); // March = 2
+      expect(result.getFullYear()).toBe(2025);
+      expect(result.getHours()).toBe(14);
+      expect(result.getMinutes()).toBe(30);
+      expect(result.getSeconds()).toBe(45);
+    });
+
+    it('should parse timestamp without seconds', () => {
+      const result = service.parseEsTimestamp('1/1/2024, 9:05');
+      expect(result).toBeInstanceOf(Date);
+      expect(result.getDate()).toBe(1);
+      expect(result.getMonth()).toBe(0);
+      expect(result.getFullYear()).toBe(2024);
+      expect(result.getHours()).toBe(9);
+      expect(result.getMinutes()).toBe(5);
+      expect(result.getSeconds()).toBe(0);
+    });
+
+    it('should parse date-only timestamp', () => {
+      const result = service.parseEsTimestamp('25/12/2023');
+      expect(result).toBeInstanceOf(Date);
+      expect(result.getDate()).toBe(25);
+      expect(result.getMonth()).toBe(11);
+      expect(result.getFullYear()).toBe(2023);
+    });
+
+    it('should return null for empty string', () => {
+      expect(service.parseEsTimestamp('')).toBeNull();
+    });
+
+    it('should return null for null input', () => {
+      expect(service.parseEsTimestamp(null)).toBeNull();
+    });
+
+    it('should return null for invalid format', () => {
+      expect(service.parseEsTimestamp('2025-03-15')).toBeNull();
+      expect(service.parseEsTimestamp('invalid')).toBeNull();
+    });
+
+    it('should handle whitespace', () => {
+      const result = service.parseEsTimestamp('  15/03/2025, 14:30:45  ');
+      expect(result).toBeInstanceOf(Date);
+      expect(result.getDate()).toBe(15);
+    });
+  });
+
+  describe('normalizeNIF', () => {
+    it('should normalize a standard DNI (8 digits + letter)', () => {
+      expect(service.normalizeNIF('12345678A')).toBe('12345678A');
+    });
+
+    it('should normalize a CIF (letter + 8 digits)', () => {
+      expect(service.normalizeNIF('B12345678')).toBe('B12345678');
+    });
+
+    it('should normalize NIF with ES prefix', () => {
+      expect(service.normalizeNIF('ES12345678A')).toBe('ES12345678A');
+    });
+
+    it('should normalize CIF with ES prefix', () => {
+      expect(service.normalizeNIF('ESB12345678')).toBe('ESB12345678');
+    });
+
+    it('should handle NIF with letter + 7 digits + letter', () => {
+      expect(service.normalizeNIF('A1234567B')).toBe('A1234567B');
+    });
+
+    it('should handle NIF with ES prefix + letter + 7 digits + letter', () => {
+      expect(service.normalizeNIF('ESA1234567B')).toBe('ESA1234567B');
+    });
+
+    it('should convert to uppercase', () => {
+      expect(service.normalizeNIF('b12345678')).toBe('B12345678');
+    });
+
+    it('should strip non-alphanumeric characters', () => {
+      expect(service.normalizeNIF('12.345.678-A')).toBe('12345678A');
+    });
+
+    it('should trim whitespace', () => {
+      expect(service.normalizeNIF('  12345678A  ')).toBe('12345678A');
+    });
+
+    it('should return empty string for empty input', () => {
+      expect(service.normalizeNIF('')).toBe('');
+    });
+
+    it('should return empty string for null/undefined', () => {
+      expect(service.normalizeNIF(null)).toBe('');
+      expect(service.normalizeNIF(undefined)).toBe('');
+    });
+
+    it('should throw for invalid NIF format', () => {
+      expect(() => service.normalizeNIF('INVALID')).toThrow('NIF inválido para BC');
+    });
+
+    it('should throw for too short NIF', () => {
+      expect(() => service.normalizeNIF('123')).toThrow('NIF inválido para BC');
+    });
+
+    it('should handle 7 digit + letter format', () => {
+      expect(service.normalizeNIF('1234567A')).toBe('1234567A');
+    });
+
+    it('should handle letter + 6 digits + letter format', () => {
+      expect(service.normalizeNIF('A123456B')).toBe('A123456B');
+    });
+  });
+
+  describe('addLog', () => {
+    it('should create log file if it does not exist', async () => {
+      mockAccess.mockRejectedValueOnce(new Error('ENOENT'));
+      mockWriteFile.mockResolvedValue(undefined);
+      mockReadFile.mockResolvedValueOnce('[]');
+      mockCopyFile.mockResolvedValue(undefined);
+
+      await service.addLog('tienda1', '2025-03-15', 'M', 'info', 'TEST', 'Test message', 'test');
+
+      // Should have created the file
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        expect.stringContaining('logs.json'),
+        '[]',
+        'utf8',
+      );
+    });
+
+    it('should append log to existing logs', async () => {
+      const existingLogs = [{ tipo: 'info', mensaje: 'old log' }];
+      mockAccess.mockResolvedValueOnce(undefined);
+      mockReadFile.mockResolvedValueOnce(JSON.stringify(existingLogs));
+      mockCopyFile.mockResolvedValue(undefined);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      await service.addLog('tienda1', '2025-03-15', 'M', 'error', 'ERR01', 'Error message', 'invoices');
+
+      const writeCall = mockWriteFile.mock.calls.find(
+        (call) => typeof call[1] === 'string' && call[1] !== '[]',
+      );
+      expect(writeCall).toBeDefined();
+      const writtenLogs = JSON.parse(writeCall[1] as string);
+      expect(writtenLogs).toHaveLength(2);
+      expect(writtenLogs[1].tipo).toBe('error');
+      expect(writtenLogs[1].codigo).toBe('ERR01');
+      expect(writtenLogs[1].mensaje).toBe('Error message');
+      expect(writtenLogs[1].tienda).toBe('tienda1');
+    });
+
+    it('should restore from backup if main file is corrupt', async () => {
+      const backupLogs = [{ tipo: 'info', mensaje: 'backup log' }];
+      mockAccess.mockResolvedValueOnce(undefined);
+      mockReadFile
+        .mockRejectedValueOnce(new Error('corrupt')) // main file
+        .mockResolvedValueOnce(JSON.stringify(backupLogs)); // backup
+      mockCopyFile.mockResolvedValue(undefined);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      await service.addLog('tienda1', '2025-03-15', 'M', 'info', 'TEST', 'msg', 'test');
+
+      const writeCall = mockWriteFile.mock.calls.find(
+        (call) => typeof call[1] === 'string' && call[1] !== '[]',
+      );
+      const writtenLogs = JSON.parse(writeCall[1] as string);
+      expect(writtenLogs).toHaveLength(2);
+      expect(writtenLogs[0].mensaje).toBe('backup log');
+    });
+
+    it('should include all log fields', async () => {
+      mockAccess.mockResolvedValueOnce(undefined);
+      mockReadFile.mockResolvedValueOnce('[]');
+      mockCopyFile.mockResolvedValue(undefined);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      await service.addLog('shop1', '2025-01-01', 'T', 'warning', 'W01', 'warn msg', 'pdf', 'company123', 'production');
+
+      const writeCall = mockWriteFile.mock.calls.find(
+        (call) => typeof call[1] === 'string' && call[1] !== '[]',
+      );
+      const writtenLogs = JSON.parse(writeCall[1] as string);
+      const log = writtenLogs[0];
+      expect(log.tienda).toBe('shop1');
+      expect(log.fecha).toBe('2025-01-01');
+      expect(log.turno).toBe('T');
+      expect(log.tipo).toBe('warning');
+      expect(log.codigo).toBe('W01');
+      expect(log.mensaje).toBe('warn msg');
+      expect(log.origen).toBe('pdf');
+      expect(log.companyID).toBe('company123');
+      expect(log.entorno).toBe('production');
+      expect(log.timestamp).toBeDefined();
+    });
+  });
+
+  describe('cleanOldLogs', () => {
+    it('should remove logs older than 2 weeks', async () => {
+      const now = new Date();
+      const oldDate = new Date(now.getTime() - 20 * 24 * 60 * 60 * 1000); // 20 days ago
+      const recentDate = new Date(now.getTime() - 1 * 24 * 60 * 60 * 1000); // 1 day ago
+
+      const formatEs = (d: Date) =>
+        `${d.getDate()}/${d.getMonth() + 1}/${d.getFullYear()}, ${d.getHours()}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}`;
+
+      const logs = [
+        { mensaje: 'old', timestamp: formatEs(oldDate) },
+        { mensaje: 'recent', timestamp: formatEs(recentDate) },
+      ];
+
+      mockAccess.mockResolvedValueOnce(undefined);
+      mockReadFile.mockResolvedValueOnce(JSON.stringify(logs));
+      mockCopyFile.mockResolvedValue(undefined);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      await service.cleanOldLogs();
+
+      const writeCall = mockWriteFile.mock.calls[0];
+      const filteredLogs = JSON.parse(writeCall[1] as string);
+      expect(filteredLogs).toHaveLength(1);
+      expect(filteredLogs[0].mensaje).toBe('recent');
+    });
+
+    it('should do nothing if log file does not exist', async () => {
+      mockAccess.mockRejectedValueOnce(new Error('ENOENT'));
+
+      await service.cleanOldLogs();
+
+      expect(mockWriteFile).not.toHaveBeenCalled();
+    });
+
+    it('should keep logs without timestamp', async () => {
+      const logs = [
+        { mensaje: 'no timestamp' },
+        { mensaje: 'empty timestamp', timestamp: '' },
+      ];
+
+      mockAccess.mockResolvedValueOnce(undefined);
+      mockReadFile.mockResolvedValueOnce(JSON.stringify(logs));
+      mockCopyFile.mockResolvedValue(undefined);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      await service.cleanOldLogs();
+
+      const writeCall = mockWriteFile.mock.calls[0];
+      const filteredLogs = JSON.parse(writeCall[1] as string);
+      expect(filteredLogs).toHaveLength(2);
+    });
+  });
+});

--- a/src/maestros/customers/customers.service.spec.ts
+++ b/src/maestros/customers/customers.service.spec.ts
@@ -1,0 +1,182 @@
+import { customersService } from './customers.service';
+import { getTokenService } from 'src/connection/getToken.service';
+import { runSqlService } from 'src/connection/sqlConnection.service';
+import { helpersService } from 'src/helpers/helpers.service';
+import axios from 'axios';
+
+jest.mock('axios');
+jest.mock('mqtt', () => ({
+  connect: jest.fn().mockReturnValue({
+    publish: jest.fn(),
+    on: jest.fn(),
+    subscribe: jest.fn(),
+  }),
+}));
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('customersService', () => {
+  let service: customersService;
+  let tokenService: jest.Mocked<getTokenService>;
+  let sqlService: jest.Mocked<runSqlService>;
+  let helpers: helpersService;
+
+  beforeEach(() => {
+    tokenService = {
+      getToken: jest.fn().mockResolvedValue('test-token'),
+      getToken2: jest.fn().mockResolvedValue('test-token'),
+    } as any;
+
+    sqlService = {
+      runSql: jest.fn(),
+      PoolCreation: jest.fn(),
+    } as any;
+
+    helpers = new helpersService();
+
+    service = new customersService(tokenService, sqlService, helpers);
+    jest.clearAllMocks();
+
+    process.env.baseURL = 'https://api.businesscentral.dynamics.com';
+    process.env.tenaTenant = 'blocked-tenant';
+
+    // Re-mock after clearAllMocks
+    tokenService.getToken2.mockResolvedValue('test-token');
+  });
+
+  describe('sanitizePhone (private)', () => {
+    it('should clean phone numbers', () => {
+      const sanitize = (service as any).sanitizePhone.bind(service);
+      expect(sanitize('934 567 890')).toBe('934 567 890');
+      expect(sanitize('+34 934567890')).toBe('+34 934567890');
+      expect(sanitize('')).toBe('');
+      expect(sanitize(null)).toBe('');
+      expect(sanitize('abc123def')).toBe('123');
+    });
+  });
+
+  describe('sanitizeIBAN (private)', () => {
+    it('should clean IBAN removing non-alphanumeric chars', () => {
+      const sanitize = (service as any).sanitizeIBAN.bind(service);
+      expect(sanitize('ES12 3456 7890 1234 5678 9012')).toBe('ES1234567890123456789012');
+      expect(sanitize('es12-3456-7890')).toBe('ES1234567890');
+      expect(sanitize('')).toBe('');
+      expect(sanitize(null)).toBe('');
+    });
+  });
+
+  describe('getPaymentMethodId', () => {
+    it('should return payment method ID when found', async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { value: [{ id: 'pm-123' }] },
+      });
+
+      const result = await service.getPaymentMethodId('EFECTIVO', 'company1', 'cid', 'cs', 'tenant', 'production');
+
+      expect(result).toBe('pm-123');
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        expect.stringContaining('paymentMethods'),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-token',
+          }),
+        }),
+      );
+    });
+
+    it('should return empty string when not found', async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { value: [] },
+      });
+
+      const result = await service.getPaymentMethodId('UNKNOWN', 'company1', 'cid', 'cs', 'tenant', 'production');
+
+      expect(result).toBe('');
+    });
+  });
+
+  describe('getTaxAreaId', () => {
+    it('should return tax area ID when found', async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { value: [{ id: 'tax-456' }] },
+      });
+
+      const result = await service.getTaxAreaId('NAC', 'company1', 'cid', 'cs', 'tenant', 'production');
+
+      expect(result).toBe('tax-456');
+    });
+  });
+
+  describe('getPaymentTermId', () => {
+    it('should return existing payment term ID', async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { value: [{ id: 'pt-789' }] },
+      });
+
+      const result = await service.getPaymentTermId('30 DÍAS', 'company1', 'cid', 'cs', 'tenant', 'production');
+
+      expect(result).toBe('pt-789');
+    });
+
+    it('should create payment term if not found', async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { value: [] },
+      });
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { id: 'pt-new' },
+      });
+
+      const result = await service.getPaymentTermId('60 DÍAS', 'company1', 'cid', 'cs', 'tenant', 'production');
+
+      expect(result).toBe('pt-new');
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        expect.stringContaining('paymentTerms'),
+        expect.objectContaining({
+          code: '60 DÍAS',
+          dueDateCalculation: '60D',
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it('should handle CON payment term', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: { value: [] } });
+      mockedAxios.post.mockResolvedValueOnce({ data: { id: 'pt-con' } });
+
+      await service.getPaymentTermId('CON', 'company1', 'cid', 'cs', 'tenant', 'production');
+
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          dueDateCalculation: '0D',
+        }),
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('syncCustomers', () => {
+    it('should skip if tenant is blocked', async () => {
+      const result = await service.syncCustomers('comp1', 'db', 'cid', 'cs', 'blocked-tenant', 'prod');
+
+      expect(sqlService.runSql).not.toHaveBeenCalled();
+      expect(result).toBeUndefined();
+    });
+
+    it('should return false when no customers found', async () => {
+      sqlService.runSql.mockResolvedValueOnce({ recordset: [] });
+
+      const result = await service.syncCustomers('comp1', 'db', 'cid', 'cs', 'tenant', 'prod');
+
+      expect(result).toBe(false);
+    });
+
+    it('should throw when no customers found with codiHIT', async () => {
+      sqlService.runSql.mockResolvedValueOnce({ recordset: [] });
+
+      await expect(
+        service.syncCustomers('comp1', 'db', 'cid', 'cs', 'tenant', 'prod', '12345678A'),
+      ).rejects.toThrow('No se encontraron registros de clientes');
+    });
+  });
+});

--- a/src/maestros/items/items.service.spec.ts
+++ b/src/maestros/items/items.service.spec.ts
@@ -1,0 +1,166 @@
+import { itemsService } from './items.service';
+import { getTokenService } from 'src/connection/getToken.service';
+import { runSqlService } from 'src/connection/sqlConnection.service';
+import axios from 'axios';
+
+jest.mock('axios');
+jest.mock('mqtt', () => ({
+  connect: jest.fn().mockReturnValue({
+    publish: jest.fn(),
+    on: jest.fn(),
+    subscribe: jest.fn(),
+  }),
+}));
+jest.mock('cli-progress', () => ({
+  SingleBar: jest.fn().mockImplementation(() => ({
+    start: jest.fn(),
+    update: jest.fn(),
+    stop: jest.fn(),
+  })),
+}));
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('itemsService', () => {
+  let service: itemsService;
+  let tokenService: jest.Mocked<getTokenService>;
+  let sqlService: jest.Mocked<runSqlService>;
+
+  beforeEach(() => {
+    tokenService = {
+      getToken: jest.fn().mockResolvedValue('test-token'),
+      getToken2: jest.fn().mockResolvedValue('test-token'),
+    } as any;
+
+    sqlService = {
+      runSql: jest.fn(),
+      PoolCreation: jest.fn(),
+    } as any;
+
+    service = new itemsService(tokenService, sqlService);
+    jest.clearAllMocks();
+
+    process.env.baseURL = 'https://api.businesscentral.dynamics.com';
+    process.env.tenaTenant = 'blocked-tenant';
+
+    tokenService.getToken2.mockResolvedValue('test-token');
+  });
+
+  describe('getBaseUnitOfMeasure (private)', () => {
+    it('should return KG when esSumable is 0', () => {
+      const fn = (service as any).getBaseUnitOfMeasure.bind(service);
+      expect(fn(0)).toBe('KG');
+    });
+
+    it('should return UDS when esSumable is 1', () => {
+      const fn = (service as any).getBaseUnitOfMeasure.bind(service);
+      expect(fn(1)).toBe('UDS');
+    });
+
+    it('should return KG when esSumable is false', () => {
+      const fn = (service as any).getBaseUnitOfMeasure.bind(service);
+      expect(fn(false)).toBe('KG');
+    });
+
+    it('should return UDS when esSumable is true', () => {
+      const fn = (service as any).getBaseUnitOfMeasure.bind(service);
+      expect(fn(true)).toBe('UDS');
+    });
+  });
+
+  describe('syncItems', () => {
+    it('should skip if tenant is blocked', async () => {
+      const result = await service.syncItems('comp1', 'db', 'cid', 'cs', 'blocked-tenant', 'prod');
+
+      expect(sqlService.runSql).not.toHaveBeenCalled();
+      expect(result).toBeUndefined();
+    });
+
+    it('should return false when no items found', async () => {
+      sqlService.runSql.mockResolvedValueOnce({ recordset: [] });
+
+      const result = await service.syncItems('comp1', 'db', 'cid', 'cs', 'tenant', 'prod');
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false on SQL error', async () => {
+      sqlService.runSql.mockRejectedValueOnce(new Error('SQL error'));
+
+      const result = await service.syncItems('comp1', 'db', 'cid', 'cs', 'tenant', 'prod');
+
+      expect(result).toBe(false);
+    });
+
+    it('should create new item when not found in BC', async () => {
+      const items = [{ Codi: '100', Nom: 'Test Item', Preu: 10.5, Familia: 'FAM1', EsSumable: 1, Iva: 21 }];
+      sqlService.runSql.mockResolvedValueOnce({ recordset: items });
+
+      // GET - item not found
+      mockedAxios.get.mockResolvedValueOnce({ data: { value: [] } });
+      // POST - create item
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { id: 'item-001', '@odata.etag': 'etag1', VATProductPostingGroup: 'IVA21' },
+      });
+      // PATCH - update priceIncludesTax
+      mockedAxios.patch.mockResolvedValueOnce({ data: {} });
+
+      const result = await service.syncItems('comp1', 'db', 'cid', 'cs', 'tenant', 'prod');
+
+      expect(result).toBe(true);
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        expect.stringContaining('/items'),
+        expect.objectContaining({
+          number: '100',
+          displayName: 'Test Item',
+          VATProductPostingGroup: 'IVA21',
+          baseUnitOfMeasureCode: 'UDS',
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it('should update existing item in BC', async () => {
+      const items = [{ Codi: '100', Nom: 'Test Item', Preu: 10.5, Familia: 'FAM1', EsSumable: 0, Iva: 10 }];
+      sqlService.runSql.mockResolvedValueOnce({ recordset: items });
+
+      // GET - item found
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { value: [{ id: 'item-existing', '@odata.etag': 'etag-old' }] },
+      });
+      // PATCH - update item
+      mockedAxios.patch.mockResolvedValueOnce({
+        data: { '@odata.etag': 'etag-new', VATProductPostingGroup: 'IVA10' },
+      });
+      // PATCH - update priceIncludesTax
+      mockedAxios.patch.mockResolvedValueOnce({ data: {} });
+
+      const result = await service.syncItems('comp1', 'db', 'cid', 'cs', 'tenant', 'prod');
+
+      expect(result).toBe(true);
+      expect(mockedAxios.patch).toHaveBeenCalledWith(
+        expect.stringContaining('item-existing'),
+        expect.objectContaining({
+          number: '100',
+          baseUnitOfMeasureCode: 'KG',
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it('should return itemId when codiHIT is provided', async () => {
+      const items = [{ Codi: '200', Nom: 'Specific Item', Preu: 5.0, Familia: 'FAM2', EsSumable: 1, Iva: 4 }];
+      sqlService.runSql.mockResolvedValueOnce({ recordset: items });
+
+      mockedAxios.get.mockResolvedValueOnce({ data: { value: [] } });
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { id: 'item-200', '@odata.etag': 'etag', VATProductPostingGroup: 'IVA4' },
+      });
+      mockedAxios.patch.mockResolvedValueOnce({ data: {} });
+
+      const result = await service.syncItems('comp1', 'db', 'cid', 'cs', 'tenant', 'prod', '200');
+
+      expect(result).toBe('item-200');
+    });
+  });
+});

--- a/src/sales/xml/xml.service.spec.ts
+++ b/src/sales/xml/xml.service.spec.ts
@@ -1,0 +1,95 @@
+import { xmlService } from './xml.service';
+import { getTokenService } from 'src/connection/getToken.service';
+import { runSqlService } from 'src/connection/sqlConnection.service';
+import axios from 'axios';
+
+jest.mock('axios');
+jest.mock('mqtt', () => ({
+  connect: jest.fn().mockReturnValue({
+    publish: jest.fn(),
+    on: jest.fn(),
+    subscribe: jest.fn(),
+  }),
+}));
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('xmlService', () => {
+  let service: xmlService;
+  let tokenService: jest.Mocked<getTokenService>;
+  let sqlService: jest.Mocked<runSqlService>;
+
+  beforeEach(() => {
+    tokenService = {
+      getToken2: jest.fn().mockResolvedValue('test-token'),
+    } as any;
+
+    sqlService = {
+      runSql: jest.fn().mockResolvedValue({}),
+    } as any;
+
+    service = new xmlService(tokenService, sqlService);
+    jest.clearAllMocks();
+
+    process.env.baseURL = 'https://api.businesscentral.dynamics.com';
+
+    tokenService.getToken2.mockResolvedValue('test-token');
+    sqlService.runSql.mockResolvedValue({});
+  });
+
+  describe('getXML', () => {
+    it('should fetch XML and upload to database', async () => {
+      // GET document number
+      mockedAxios.get
+        .mockResolvedValueOnce({ data: { number: 'INV-001' } })
+        // GET edocLog
+        .mockResolvedValueOnce({ data: { value: [{ storageEntryNo: 42 }] } })
+        // GET xml content
+        .mockResolvedValueOnce({ data: '<xml>test</xml>' });
+
+      // Mock subirXml (which calls getToken2 + axios.get + runSql)
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { postingDate: '2025-03-15' },
+      });
+
+      const result = await service.getXML('comp1', 'testdb', 'cid', 'cs', 'tenant', 'prod', 'id-123', 'salesInvoices');
+
+      expect(result).toBe(true);
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        expect.stringContaining('salesInvoices(id-123)'),
+        expect.any(Object),
+      );
+    });
+
+    it('should return false on error', async () => {
+      mockedAxios.get
+        .mockResolvedValueOnce({ data: { number: 'INV-001' } })
+        .mockRejectedValueOnce(new Error('API Error'));
+
+      const result = await service.getXML('comp1', 'testdb', 'cid', 'cs', 'tenant', 'prod', 'id-123', 'salesInvoices');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('subirXml', () => {
+    it('should convert base64 to hex and save to database', async () => {
+      const base64Content = Buffer.from('<xml>test</xml>').toString('base64');
+
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { postingDate: '2025-03-15' },
+      });
+
+      await service.subirXml('fact-001', base64Content, 'testdb', 'cid', 'cs', 'tenant', 'prod', 'comp1', 'salesInvoices');
+
+      expect(sqlService.runSql).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE BC_SyncSales_2025'),
+        'testdb',
+      );
+      expect(sqlService.runSql).toHaveBeenCalledWith(
+        expect.stringContaining("BC_IdSale='fact-001'"),
+        'testdb',
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds **71 unit tests** across **8 test suites** covering the core services of the application
- Configures Jest `moduleNameMapper` for `src/` path resolution
- Adds SSH key patterns to `.gitignore`

## Test suites detail

### Connection layer
| File | Tests | Coverage |
|------|-------|----------|
| `getToken.service.spec.ts` | 7 | `getToken()` / `getToken2()` with custom credentials, error handling (no data, network errors), correct OAuth params |
| `sqlConnection.service.spec.ts` | 3 | Pool creation, `USE <db>` prefix injection, query result handling |
| `azureSASToken.service.spec.ts` | 5 | SAS URL generation (container/blob level), `rwcm` permissions, expiry calculation, storage account config |

### Helpers
| File | Tests | Coverage |
|------|-------|----------|
| `helpers.service.spec.ts` | 29 | `parseEsTimestamp` (7 cases: full/partial timestamps, null, invalid, whitespace), `normalizeNIF` (13 cases: DNI, CIF, ES prefix, uppercase, strip chars, invalid), `addLog` (4 cases: create file, append, backup restore, all fields), `cleanOldLogs` (3 cases: 2-week filter, missing file, no timestamp) |
| `helpers.controller.spec.ts` | 3 | `GET /helpers` endpoint: parse logs, empty array, invalid JSON |

### Maestros (master data)
| File | Tests | Coverage |
|------|-------|----------|
| `customers.service.spec.ts` | 11 | `sanitizePhone` (5 inputs), `sanitizeIBAN` (4 inputs), `getPaymentMethodId` (found/not found), `getTaxAreaId`, `getPaymentTermId` (existing/create/CON), `syncCustomers` (blocked tenant, no records, codiHIT error) |
| `items.service.spec.ts` | 10 | `getBaseUnitOfMeasure` (KG/UDS for 0/1/false/true), `syncItems` (blocked tenant, no items, SQL error, create new item in BC, update existing item, return itemId with codiHIT) |

### Sales
| File | Tests | Coverage |
|------|-------|----------|
| `xml.service.spec.ts` | 3 | `getXML` (fetch + upload flow, error handling), `subirXml` (base64→hex conversion, SQL UPDATE with year extraction) |

## Config changes

- **`package.json`**: Added `moduleNameMapper: { "^src/(.*)$": "<rootDir>/$1" }` to Jest config for `src/` absolute imports
- **`.gitignore`**: Added `id_ed25519*` pattern to prevent SSH keys from being committed

## Test plan

- [x] All 71 tests pass (`npm test`)
- [x] Zero compilation errors
- [ ] Review mocks match actual service signatures
- [ ] Verify no sensitive data in test fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)