### PR TITLE
feat: Vendors sync for Factures Rebudes

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,9 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1"
+    }
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -18,6 +18,7 @@ import { SigningsModule } from './silema/signings/signings.module';
 import { TrabajadoresModule } from './silema/trabajadores/trabajadores.module';
 import { PeticionesMqttModule } from './webPeticionesMqtt/peticionesMqtt.module';
 import { noSerieModule } from './sales/noSerie/noSerie.module';
+import { VendorsModule } from './maestros/vendors/vendors.module';
 
 
 @Module({
@@ -40,6 +41,7 @@ import { noSerieModule } from './sales/noSerie/noSerie.module';
     TrabajadoresModule,
     PeticionesMqttModule,
     noSerieModule,
+    VendorsModule,
   ],
   controllers: [],
   providers: [],

--- a/src/maestros/maestros.module.ts
+++ b/src/maestros/maestros.module.ts
@@ -4,9 +4,10 @@ import { LocationsModule } from './locations/locations.module';
 import { CustomersModule } from './customers/customer.module';
 import { ItemCategoriesModule } from './itemCategories/itemCategories.module';
 import { SalespersonModule } from './salesperson/salesperson.module';
+import { VendorsModule } from './vendors/vendors.module';
 
 @Module({
-    imports: [ItemsModule, LocationsModule, CustomersModule, ItemCategoriesModule, SalespersonModule],
-    exports: [ItemsModule, LocationsModule, CustomersModule, ItemCategoriesModule, SalespersonModule],
+    imports: [ItemsModule, LocationsModule, CustomersModule, ItemCategoriesModule, SalespersonModule, VendorsModule],
+    exports: [ItemsModule, LocationsModule, CustomersModule, ItemCategoriesModule, SalespersonModule, VendorsModule],
 })
 export class MaestrosModule { }

--- a/src/maestros/vendors/vendors.controller.ts
+++ b/src/maestros/vendors/vendors.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { vendorsService } from './vendors.service';
+
+@Controller()
+export class vendorsController {
+  constructor(private vendorsService: vendorsService) {}
+
+  @Get('syncVendors')
+  async syncVendors(
+    @Query('companyID') companyID: string,
+    @Query('database') database: string,
+    @Query('client_id') client_id: string,
+    @Query('client_secret') client_secret: string,
+    @Query('tenant') tenant: string,
+    @Query('entorno') entorno: string,
+  ) {
+    return this.vendorsService.syncVendors(companyID, database, client_id, client_secret, tenant, entorno);
+  }
+}

--- a/src/maestros/vendors/vendors.module.ts
+++ b/src/maestros/vendors/vendors.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { vendorsController } from './vendors.controller';
+import { vendorsService } from './vendors.service';
+import { ConnectionModule } from 'src/connection/connection.module';
+import { HelpersModule } from 'src/helpers/helpers.module';
+
+@Module({
+  imports: [ConnectionModule, HelpersModule],
+  controllers: [vendorsController],
+  providers: [vendorsService],
+  exports: [vendorsService],
+})
+export class VendorsModule {}

--- a/src/maestros/vendors/vendors.service.spec.ts
+++ b/src/maestros/vendors/vendors.service.spec.ts
@@ -1,0 +1,168 @@
+import { vendorsService } from './vendors.service';
+import { getTokenService } from 'src/connection/getToken.service';
+import { runSqlService } from 'src/connection/sqlConnection.service';
+import { helpersService } from 'src/helpers/helpers.service';
+import axios from 'axios';
+
+jest.mock('axios');
+jest.mock('mqtt', () => ({
+  connect: jest.fn().mockReturnValue({
+    publish: jest.fn(),
+    on: jest.fn(),
+    subscribe: jest.fn(),
+  }),
+}));
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('vendorsService', () => {
+  let service: vendorsService;
+  let tokenService: jest.Mocked<getTokenService>;
+  let sqlService: jest.Mocked<runSqlService>;
+  let helpers: helpersService;
+
+  beforeEach(() => {
+    tokenService = {
+      getToken: jest.fn().mockResolvedValue('test-token'),
+      getToken2: jest.fn().mockResolvedValue('test-token'),
+    } as any;
+
+    sqlService = {
+      runSql: jest.fn(),
+      PoolCreation: jest.fn(),
+    } as any;
+
+    helpers = new helpersService();
+
+    service = new vendorsService(tokenService, sqlService, helpers);
+    jest.clearAllMocks();
+
+    process.env.baseURL = 'https://api.businesscentral.dynamics.com';
+    process.env.tenaTenant = 'blocked-tenant';
+
+    // Re-mock after clearAllMocks
+    tokenService.getToken2.mockResolvedValue('test-token');
+  });
+
+  describe('sanitizePhone', () => {
+    it('should clean phone numbers', () => {
+      expect(service.sanitizePhone('934 567 890')).toBe('934 567 890');
+      expect(service.sanitizePhone('+34 934567890')).toBe('+34 934567890');
+      expect(service.sanitizePhone('')).toBe('');
+      expect(service.sanitizePhone(null)).toBe('');
+      expect(service.sanitizePhone('abc123def')).toBe('123');
+    });
+  });
+
+  describe('sanitizeIBAN', () => {
+    it('should clean IBAN removing non-alphanumeric chars', () => {
+      expect(service.sanitizeIBAN('ES12 3456 7890 1234 5678 9012')).toBe('ES1234567890123456789012');
+      expect(service.sanitizeIBAN('es12-3456-7890')).toBe('ES1234567890');
+      expect(service.sanitizeIBAN('')).toBe('');
+      expect(service.sanitizeIBAN(null)).toBe('');
+    });
+  });
+
+  describe('getPaymentMethodId', () => {
+    it('should return payment method ID when found', async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { value: [{ id: 'pm-123' }] },
+      });
+
+      const result = await service.getPaymentMethodId('EFECTIVO', 'company1', 'cid', 'cs', 'tenant', 'production');
+
+      expect(result).toBe('pm-123');
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        expect.stringContaining('paymentMethods'),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-token',
+          }),
+        }),
+      );
+    });
+
+    it('should return empty string when not found', async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { value: [] },
+      });
+
+      const result = await service.getPaymentMethodId('UNKNOWN', 'company1', 'cid', 'cs', 'tenant', 'production');
+
+      expect(result).toBe('');
+    });
+  });
+
+  describe('getPaymentTermId', () => {
+    it('should return existing payment term ID', async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { value: [{ id: 'pt-789' }] },
+      });
+
+      const result = await service.getPaymentTermId('30 DÍAS', 'company1', 'cid', 'cs', 'tenant', 'production');
+
+      expect(result).toBe('pt-789');
+    });
+
+    it('should create payment term if not found with days', async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { value: [] },
+      });
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { id: 'pt-new' },
+      });
+
+      const result = await service.getPaymentTermId('60 DÍAS', 'company1', 'cid', 'cs', 'tenant', 'production');
+
+      expect(result).toBe('pt-new');
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        expect.stringContaining('paymentTerms'),
+        expect.objectContaining({
+          code: '60 DÍAS',
+          dueDateCalculation: '60D',
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it('should handle CON payment term', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: { value: [] } });
+      mockedAxios.post.mockResolvedValueOnce({ data: { id: 'pt-con' } });
+
+      await service.getPaymentTermId('CON', 'company1', 'cid', 'cs', 'tenant', 'production');
+
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          dueDateCalculation: '0D',
+        }),
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('syncVendors', () => {
+    it('should skip if tenant is blocked', async () => {
+      const result = await service.syncVendors('comp1', 'db', 'cid', 'cs', 'blocked-tenant', 'prod');
+
+      expect(sqlService.runSql).not.toHaveBeenCalled();
+      expect(result).toBeUndefined();
+    });
+
+    it('should return false when no vendors found', async () => {
+      sqlService.runSql.mockResolvedValueOnce({ recordset: [] });
+
+      const result = await service.syncVendors('comp1', 'db', 'cid', 'cs', 'tenant', 'prod');
+
+      expect(result).toBe(false);
+    });
+
+    it('should throw when no vendors found with codiHIT', async () => {
+      sqlService.runSql.mockResolvedValueOnce({ recordset: [] });
+
+      await expect(
+        service.syncVendors('comp1', 'db', 'cid', 'cs', 'tenant', 'prod', '12345678A'),
+      ).rejects.toThrow('No se encontraron registros de proveedores');
+    });
+  });
+});

--- a/src/maestros/vendors/vendors.service.ts
+++ b/src/maestros/vendors/vendors.service.ts
@@ -1,0 +1,257 @@
+import { Injectable } from '@nestjs/common';
+import { getTokenService } from 'src/connection/getToken.service';
+import { runSqlService } from 'src/connection/sqlConnection.service';
+import { helpersService } from 'src/helpers/helpers.service';
+import axios from 'axios';
+import * as mqtt from 'mqtt';
+
+@Injectable()
+export class vendorsService {
+  private client = mqtt.connect({
+    host: process.env.MQTT_HOST,
+    username: process.env.MQTT_USER,
+    password: process.env.MQTT_PASSWORD,
+  });
+
+  constructor(
+    private tokenService: getTokenService,
+    private sqlService: runSqlService,
+    private helpers: helpersService,
+  ) { }
+
+  private async getIdFromAPI(endpoint: string, filter: string, companyID: string, client_id: string, client_secret: string, tenant: string, entorno: string): Promise<string> {
+    try {
+      const token = await this.tokenService.getToken2(client_id, client_secret, tenant);
+      const url = `${process.env.baseURL}/v2.0/${tenant}/${entorno}/api/v2.0/companies(${companyID})/${endpoint}?$filter=${filter}`;
+      const res = await axios.get(url, {
+        headers: {
+          Authorization: 'Bearer ' + token,
+          'Content-Type': 'application/json',
+        },
+      });
+      return res.data.value.length === 0 ? '' : res.data.value[0].id;
+    } catch (error) {
+      this.logError(`❌ Error obteniendo ID desde API para endpoint ${endpoint}`, error);
+      throw error;
+    }
+  }
+
+  async getPaymentMethodId(pMethodCode: string, companyID: string, client_id: string, client_secret: string, tenant: string, entorno: string) {
+    const id = await this.getIdFromAPI('paymentMethods', `code eq '${pMethodCode}'`, companyID, client_id, client_secret, tenant, entorno);
+    return id;
+  }
+
+  async getPaymentTermId(pTermCode: string, companyID: string, client_id: string, client_secret: string, tenant: string, entorno: string) {
+    let id = '';
+    const token = await this.tokenService.getToken2(client_id, client_secret, tenant);
+    let res;
+    try {
+      res = await axios.get(`${process.env.baseURL}/v2.0/${tenant}/${entorno}/api/v2.0/companies(${companyID})/paymentTerms?$filter=code eq '${pTermCode}'`, {
+        headers: {
+          Authorization: 'Bearer ' + token,
+          'Content-Type': 'application/json',
+        },
+      });
+    } catch (error) {
+      this.logError(`❌ Error al obtener el ID del término de pago ${pTermCode}`, error);
+      throw error;
+    }
+    if (res.data.value.length === 0) {
+      let paymentTerm;
+      try {
+        let dueDateCalculation = '';
+        // Extraer la parte antes de ' DÍAS'
+        const formulaPart = pTermCode.replace(' DÍAS', '').trim();
+        // Si es 'CON', la fórmula de fecha en BC debe ser '0D'
+        if (formulaPart === 'CON') {
+          dueDateCalculation = '0D';
+        } else if (/^[0-9]+$/.test(formulaPart)) {
+          // Si es solo un número, le añadimos 'D'.
+          dueDateCalculation = `${formulaPart}D`;
+        } else {
+          // Si ya tiene una unidad de tiempo (D, W, M, Q, Y), lo dejamos tal cual.
+          dueDateCalculation = formulaPart;
+        }
+
+        const paymentTermData = {
+          code: `${pTermCode}`,
+          displayName: `Neto ${pTermCode}`,
+          dueDateCalculation: dueDateCalculation,
+          discountDateCalculation: '',
+          discountPercent: 0,
+          calculateDiscountOnCreditMemos: true,
+        };
+
+        paymentTerm = await axios.post(`${process.env.baseURL}/v2.0/${tenant}/${entorno}/api/v2.0/companies(${companyID})/paymentTerms`, paymentTermData, {
+          headers: {
+            Authorization: 'Bearer ' + token,
+            'Content-Type': 'application/json',
+          },
+        });
+      } catch (error) {
+        this.logError(`❌ Error creando el término de pago ${pTermCode}`, error);
+        throw error;
+      }
+      id = paymentTerm.data.id;
+    } else {
+      id = res.data.value[0].id;
+    }
+    return id;
+  }
+
+  async syncVendors(companyID: string, database: string, client_id: string, client_secret: string, tenant: string, entorno: string, codiHIT?: string) {
+    if (tenant === process.env.tenaTenant) return;
+    let vendors;
+    try {
+      const sqlQuery = `
+        SELECT p.codi AS CODIGO, p.NomFiscal AS NOMBREFISCAL, p.Nom AS NOMBRE, p.Nif AS NIF, p.Adresa AS DIRECCION, p.Ciutat AS CIUDAD, p.Cp AS CP, p.email AS EMAIL, p.tel AS TELEFONO, p.IBAN AS IBAN,
+              CASE p.FormaPago WHEN '1' THEN 'DOM.' WHEN '2' THEN 'CHEQUE' WHEN '3' THEN 'EFECTIVO' WHEN '4' THEN 'TRANSF.' ELSE 'UNDEFINED' END AS FORMAPAGO,
+              CASE p.Venciment WHEN '' THEN 'CON' ELSE p.Venciment + ' DÍAS' END AS TERMINOPAGO
+        FROM Proveidor p
+        WHERE p.Nif IS NOT NULL AND p.Nif <> '' AND LEN(p.Nif) >= 9 ${codiHIT ? `AND p.Nif = '${codiHIT}'` : ''}
+        ORDER BY p.codi;
+      `;
+      vendors = await this.sqlService.runSql(sqlQuery, database);
+    } catch (error) {
+      this.logError(`❌ Error al ejecutar la consulta SQL en la base de datos '${database}'`, error);
+      throw error;
+    }
+
+    if (vendors.recordset.length === 0 && codiHIT) {
+      this.client.publish('/Hit/Serveis/Apicultor/Log', 'No hay registros');
+      console.error('⚠️ Advertencia: No se encontraron registros de proveedores para el código HIT proporcionado');
+      throw new Error('No se encontraron registros de proveedores para el código HIT proporcionado');
+    }
+
+    if (vendors.recordset.length === 0) {
+      this.client.publish('/Hit/Serveis/Apicultor/Log', 'No hay registros');
+      console.error('⚠️ Advertencia: No se encontraron registros de proveedores');
+      return false;
+    }
+
+    const token = await this.tokenService.getToken2(client_id, client_secret, tenant);
+
+    let vendorId = '';
+    let vendorNumber = '';
+    let i = 1;
+    for (const vendor of vendors.recordset) {
+      try {
+        const payMethodId = await this.getPaymentMethodId(vendor.FORMAPAGO, companyID, client_id, client_secret, tenant, entorno);
+        const payTermId = await this.getPaymentTermId(vendor.TERMINOPAGO, companyID, client_id, client_secret, tenant, entorno);
+        vendorNumber = `${this.helpers.normalizeNIF(vendor.NIF)}`;
+        const vendorData = {
+          number: vendorNumber,
+          displayName: `${vendor.NOMBREFISCAL}` || `${vendor.NOMBRE}`,
+          addressLine1: `${vendor.DIRECCION}`,
+          city: `${vendor.CIUDAD}`,
+          country: 'ES',
+          postalCode: `${vendor.CP}`,
+          phoneNumber: this.sanitizePhone(vendor.TELEFONO),
+          email: `${vendor.EMAIL}`,
+          taxRegistrationNumber: vendorNumber,
+          currencyCode: 'EUR',
+          paymentMethodId: `${payMethodId}`,
+          paymentTermsId: `${payTermId}`,
+          vendorPostingGroup: 'NAC',
+          GenBusPostingGroup: 'NAC',
+          iban: this.sanitizeIBAN(vendor.IBAN),
+        };
+        let res;
+        try {
+          res = await axios.get(`${process.env.baseURL}/v2.0/${tenant}/${entorno}/api/HitSystems/HitSystems/v2.0/companies(${companyID})/vendors?$filter=number eq '${vendorNumber}'`, {
+            headers: {
+              Authorization: 'Bearer ' + token,
+              'Content-Type': 'application/json',
+            },
+          });
+        } catch (error) {
+          this.logError(`❌ Error consultando el proveedor en BC con código ${vendor.CODIGO}`, error);
+          continue;
+        }
+        if (res.data.value.length === 0) {
+          const createVendor = await axios.post(`${process.env.baseURL}/v2.0/${tenant}/${entorno}/api/HitSystems/HitSystems/v2.0/companies(${companyID})/vendors`, vendorData, {
+            headers: {
+              Authorization: 'Bearer ' + token,
+              'Content-Type': 'application/json',
+            },
+          });
+          vendorId = createVendor.data.id;
+        } else {
+          const etag = res.data.value[0]['@odata.etag'];
+          await axios.patch(`${process.env.baseURL}/v2.0/${tenant}/${entorno}/api/HitSystems/HitSystems/v2.0/companies(${companyID})/vendors(${res.data.value[0].id})`, vendorData, {
+            headers: {
+              Authorization: 'Bearer ' + token,
+              'Content-Type': 'application/json',
+              'If-Match': etag,
+            },
+          });
+          vendorId = res.data.value[0].id;
+        }
+      } catch (error) {
+        this.logError(`❌ Error al procesar el proveedor ${vendor.CODIGO}:`, error);
+        if (codiHIT) {
+          throw error;
+        }
+        continue;
+      }
+      console.log(`⏳ Sincronizando proveedor ${vendor.NOMBREFISCAL} ... -> ${i}/${vendors.recordset.length} --- ${((i / vendors.recordset.length) * 100).toFixed(2)}% `);
+      i++;
+    }
+    if (codiHIT) {
+      return { vendorNumber, vendorId };
+    }
+    return true;
+  }
+
+  async getVendorFromAPI(companyID, database, codiHIT, client_id: string, client_secret: string, tenant: string, entorno: string) {
+    let vendorData;
+    const token = await this.tokenService.getToken2(client_id, client_secret, tenant);
+    let res;
+    try {
+      res = await axios.get(`${process.env.baseURL}/v2.0/${tenant}/${entorno}/api/HitSystems/HitSystems/v2.0/companies(${companyID})/vendors?$filter=number eq '${this.helpers.normalizeNIF(codiHIT)}'`, {
+        headers: {
+          Authorization: 'Bearer ' + token,
+          'Content-Type': 'application/json',
+        },
+      });
+    } catch (error) {
+      this.logError(`❌ Error consultando proveedor con código ${codiHIT}`, error);
+      throw error;
+    }
+
+    if (res.data.value.length > 0) {
+      // Si el proveedor ya existe, forzar sincronización para actualizar datos
+      vendorData = await this.syncVendors(companyID, database, client_id, client_secret, tenant, entorno, codiHIT);
+      console.log('📘 Proveedor existente en la API con ID:', vendorData.vendorId);
+      return vendorData;
+    }
+
+    const newVendor = await this.syncVendors(companyID, database, client_id, client_secret, tenant, entorno, codiHIT);
+    if (newVendor && typeof newVendor !== 'boolean') {
+      console.log('📘 Nuevo proveedor sincronizado con ID:', newVendor.vendorId);
+      vendorData = newVendor;
+      return vendorData;
+    } else {
+      console.log('⚠️ No se pudo sincronizar el nuevo proveedor.');
+      return false;
+    }
+  }
+
+  private logError(message: string, error: any) {
+    const errorDetail = error?.response?.data || error?.message || 'Error desconocido';
+    this.client.publish('/Hit/Serveis/Apicultor/Log', JSON.stringify({ message, error: errorDetail }));
+    console.error(message, errorDetail);
+  }
+
+  sanitizePhone(phone: string): string {
+    if (!phone) return '';
+    const cleaned = phone.replace(/[^0-9+\-()\s]/g, '');
+    return cleaned.trim();
+  }
+
+  sanitizeIBAN(iban: string): string {
+    if (!iban) return '';
+    const cleaned = iban.replace(/[^A-Z0-9]/gi, '');
+    return cleaned.toUpperCase();
+  }
+}


### PR DESCRIPTION
## Summary - Closes #197 (parcial)

Implementa la sincronització de **proveïdors** (vendors) des de la BBDD HIT cap a Business Central, primer pas per a la funcionalitat de Factures Rebudes.

## Canvis

### Nous fitxers
- **`src/maestros/vendors/vendors.service.ts`** (257 línies) — Servei principal
  - `syncVendors()` — Consulta taula `Proveidor` de HIT i crea/actualitza vendors a BC
  - `getVendorFromAPI()` — Obté vendor per NIF o el sincronitza si no existeix
  - `getPaymentMethodId()` / `getPaymentTermId()` — Cerca o crea mètodes/termes de pagament
  - `sanitizePhone()` / `sanitizeIBAN()` — Neteja i valida dades
  - Logging via MQTT i `helpersService`
- **`src/maestros/vendors/vendors.controller.ts`** — Endpoint `GET /syncVendors`
- **`src/maestros/vendors/vendors.module.ts`** — Mòdul NestJS amb imports de ConnectionModule i HelpersModule

### Fitxers modificats
- **`src/maestros/maestros.module.ts`** — Afegit VendorsModule a imports/exports
- **`src/app.module.ts`** — Afegit VendorsModule
- **`package.json`** — Afegit `moduleNameMapper` a Jest config

### Tests (10 tests)
- **`src/maestros/vendors/vendors.service.spec.ts`**
  - `sanitizePhone`: 5 inputs (espais, +34, buit, null, lletres)
  - `sanitizeIBAN`: 4 inputs (espais, guions, buit, null)
  - `getPaymentMethodId`: trobat / no trobat
  - `getPaymentTermId`: existent / crear amb dies / CON
  - `syncVendors`: tenant bloquejat, sense proveïdors, error amb codiHIT

## Endpoint API BC
```
GET/POST/PATCH api/HitSystems/HitSystems/v2.0/companies({companyID})/vendors
```

## Test plan
- [x] 10 tests passen
- [ ] Test manual amb dades reals de proveïdors
- [ ] Verificar creació de vendors a BC sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)